### PR TITLE
Make Plots ignore touch events.

### DIFF
--- a/AnkiU/Pages/StatsPage.xaml
+++ b/AnkiU/Pages/StatsPage.xaml
@@ -64,6 +64,7 @@
                 </StackPanel>
 
                 <oxy:PlotView Grid.Row="1" 
+                              IsHitTestVisible="False"
                               x:Name="foreCastPlotView" 
                               Background="{Binding Background, ElementName=statsTextRoot}" 
                               Margin="0,30,0,0"
@@ -76,7 +77,7 @@
                         <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
                     </Grid.RowDefinitions>
-                    <oxy:PlotView  x:Name="reviewPlotView" Height="300"  MinHeight="300"  />
+                    <oxy:PlotView  x:Name="reviewPlotView" Height="300"  MinHeight="300" IsHitTestVisible="False" />
                     <Grid Grid.Row="1" VerticalAlignment="Top" HorizontalAlignment="Stretch" 
                         Background="Transparent">
                         <Grid.ColumnDefinitions>
@@ -103,6 +104,7 @@
                 <oxy:PlotView Grid.Row="3" 
                               Background="{Binding Background, ElementName=statsTextRoot}" 
                               Margin="0,30,0,0"
+                              IsHitTestVisible="False"
                               x:Name="cardTypePlotView" Height="300" MinHeight="300"  />
             </Grid>
         </ScrollViewer>


### PR DESCRIPTION
I had a problem that touch did not work on Plots. I couldn't scroll the statistics.

I havn't seen that the plots do anything with touch input. So I could fix it with disabling input on those plots.